### PR TITLE
Push avatar-galery-video-files-to-firebasestorage

### DIFF
--- a/sth_app/lib/pages/profilescreen/accountprofilescreen.dart
+++ b/sth_app/lib/pages/profilescreen/accountprofilescreen.dart
@@ -78,18 +78,19 @@ class _AccountProfileScreenState extends State<AccountProfileScreen> {
     return null;
   }
 
-  // Function to pick images
+  // Function to pick images & upload in firebasse
   Future<void> _pickImage() async {
     try {
       final pickedFile = await picker.pickImage(source: ImageSource.gallery);
       if (pickedFile != null) {
         final File imageFile = File(pickedFile.path);
-        _saveAvatarImage(imageFile); // Save profile image in local storage
-        setState(() {
-          _avatarImage = imageFile;
-        });
-      } else {
-        print('User cancelled the image selection process.');
+        await _saveAvatarImage(imageFile);
+        bool success = await uploadAvatarImageToFirebase(imageFile);
+        if (success) {
+          setState(() {
+            _avatarImage = imageFile;
+          });
+        } 
       }
     } catch (e) {
       print('Error accessing the gallery: $e');

--- a/sth_app/lib/pages/profilescreen/profilescreen.dart
+++ b/sth_app/lib/pages/profilescreen/profilescreen.dart
@@ -230,8 +230,15 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                 for (XFile image in images) {
                                   final String newPath = await _saveImage(image.path);
                                   setState(() {
-                                    _imagePaths.insert(0, newPath); // Insert added image at first position
+                                    _imagePaths.insert(0, newPath); 
                                     _saveImagePathsToLocalStorage();
+                                  });
+                                    uploadGaleryImageToFirebase(File(newPath))
+                                  .then((success) {
+                                    //logic
+                                  })
+                                  .catchError((error) {
+                                    print('error uploading the image: $error');
                                   });
                                 }
                               }

--- a/sth_app/lib/technical/firebase_tools/firebase_tools.dart
+++ b/sth_app/lib/technical/firebase_tools/firebase_tools.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/scheduler.dart';
 
 // Authentication
 Future<void> signUpWithEmailAndPassword(String email, String password) async {
@@ -48,7 +51,7 @@ Future<void> updateUsername(String newUsername) async {
   }
 }
 
-// Push values from AccountPage to Cloud Firestore
+// Push profile details from accountprofilescreen to Firestore Cloud
 Future<void> updateUserData({
   required String name,
   required String phone,
@@ -69,3 +72,59 @@ Future<void> updateUserData({
     rethrow;
   }
 }
+
+// Push avatarImage from accountprofilescreen to Firestore Storage
+Future<bool> uploadAvatarImageToFirebase(File imageFile) async {
+  try {
+    const String userId = 'JN2dcl4RbBNSs7VGEbYZ';
+
+    final storageRef = FirebaseStorage.instance.ref();
+    final fileName = imageFile.path.split("/").last;
+    final timestamp = DateTime.now().microsecondsSinceEpoch;
+    final uploadRef = storageRef.child("$userId/uploads/avatarImages/$timestamp-$fileName");
+    await uploadRef.putFile(imageFile);
+
+    return true;
+  } catch (e) {
+    print('error uploading the avatar: $e');
+    rethrow;
+  }
+}
+
+// Push galeryImage from profilescreen to Firestore Storage
+Future<bool> uploadGaleryImageToFirebase(File imageFile) async {
+  try {
+    const String userId = 'JN2dcl4RbBNSs7VGEbYZ';
+
+    final storageRef = FirebaseStorage.instance.ref();
+    final fileName = imageFile.path.split("/").last;
+    final timestamp = DateTime.now().microsecondsSinceEpoch;
+    final uploadRef = storageRef.child("$userId/uploads/galery/$timestamp-$fileName");
+    await uploadRef.putFile(imageFile);
+
+    return true;
+  } catch (e) {
+    print('error uploading the image: $e');
+    rethrow;
+  }
+}
+
+// Push videofile from profilescreen to Firestore Storage
+Future<bool> uploadVideoFileToFirebase(File videofile) async {
+  try {
+    const String userId = 'JN2dcl4RbBNSs7VGEbYZ';
+
+    final storageRef = FirebaseStorage.instance.ref();
+    final fileName = videofile.path.split("/").last;
+    final timestamp = DateTime.now().microsecondsSinceEpoch;
+    final uploadRef = storageRef.child("$userId/uploads/videos/$timestamp-$fileName");
+    await uploadRef.putFile(videofile);
+
+    return true;
+  } catch (e) {
+    print('error uploading the video: $e');
+    rethrow;
+  }
+}
+
+

--- a/sth_app/pubspec.lock
+++ b/sth_app/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "0cb43f83f36ba8cb20502dee0c205e3f3aafb751732d724aeac3f2e044212cc2"
+      sha256: "3dee3db3468c5f4640a4e8aa9c1e22561c298976d8c39ed2fdd456a9a3db26e1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.29"
+    version: "1.3.32"
   after_layout:
     dependency: transitive
     description:
@@ -429,10 +429,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: a864d1b6afd25497a3b57b016886d1763df52baaa69758a46723164de8d187fe
+      sha256: "4aef2a23d0f3265545807d68fbc2f76a6b994ca3c778d88453b99325abd63284"
       url: "https://pub.dev"
     source: hosted
-    version: "2.29.0"
+    version: "2.30.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -445,10 +445,34 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: c8b02226e548f35aace298e2bb2e6c24e34e8a203d614e742bb1146e5a4ad3c8
+      sha256: "67f2fcc600fc78c2f731c370a3a5e6c87ee862e3a2fba6f951eca6d5dafe5c29"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.16.0"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      sha256: "9125c6e017833f51eef84f4feff2b7d6de20c36a9aa9f80fd3e9092b2a5b01a8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.7.4"
+  firebase_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_storage_platform_interface
+      sha256: "3d18f72b6059b20438266d5efed466a6a78dfe4366b619945d54963b61ea72bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.19"
+  firebase_storage_web:
+    dependency: transitive
+    description:
+      name: firebase_storage_web
+      sha256: "53fcd9d5bbe5539f9d69b337e632e67658882857736aa1dcc996b34daaafb113"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.4"
   fixnum:
     dependency: transitive
     description:

--- a/sth_app/pubspec.yaml
+++ b/sth_app/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   firebase_core: ^2.27.2
   firebase_auth: ^4.18.0
   cloud_firestore: ^4.15.10
+  firebase_storage: ^11.7.4
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This feature contains the following functionalities:

Initial setup for Firebase Storage:
- [Firebase Storage Setup](https://console.firebase.google.com/u/1/project/sth-app-ec9fa/storage/sth-app-ec9fa.appspot.com/files)

Initial rules for Firebase Storage have been set up.

Functions to push images to Firebase Storage:
- uploadAvatarImageToFirebase(); Uploads avatar images.
- uploadGalleryImageToFirebase(); Uploads gallery images.
- uploadVideoFileToFirebase(); Uploads video files.

Paths per user have been set up:
- Avatar images: `"$userId/uploads/avatar/$timestamp-$fileName"` (with the timestamp of files)
- Gallery images: `"$userId/uploads/gallery/$timestamp-$fileName"` (with the timestamp of files)
- Video files: `"$userId/uploads/videos/$timestamp-$fileName"` (with the timestamp of files)